### PR TITLE
Workaround to prevent crashes due to NullPointerExceptions

### DIFF
--- a/src/android/ActivityRecognitionIntentService.java
+++ b/src/android/ActivityRecognitionIntentService.java
@@ -39,10 +39,14 @@ public class ActivityRecognitionIntentService extends IntentService {
       ActivityRecognitionResult result = ActivityRecognitionResult.extractResult(intent);
       DetectedActivity CurrentActivity = result.getMostProbableActivity();
 
-      Activity.ActivityType = ConvertActivityCodeToString(CurrentActivity);
-      Activity.Probability = CurrentActivity.getConfidence();
+      if (Activity != null) {
+          Activity.ActivityType = ConvertActivityCodeToString(CurrentActivity);
+          Activity.Probability = CurrentActivity.getConfidence();
+      }
     } else {
-      Activity.ActivityType = "NoResult";
+        if (Activity != null) {
+            Activity.ActivityType = "NoResult";
+        }
     }
   }
 }


### PR DESCRIPTION
`Activity.ActivityType =` was responsible for throwing `NullPointerException`s.
